### PR TITLE
v1.2.3: Remitos - botón eliminar con soft delete y permisos por perfil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Todas las modificaciones importantes de este proyecto se documentan en este arch
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.1.0/),
 y este proyecto sigue [Versionado Semantico](https://semver.org/lang/es/).
 
+## [1.2.3] - 2026-02-23
+
+### Agregado
+- **Remitos**: botón eliminar remitos en estado Espera con soft delete
+- Nuevo módulo de permiso `remitos_eliminar` para control de acceso por perfil
+- Al eliminar un remito se decrementa el contador del proveedor (mínimo 1)
+- Confirmación SweetAlert2 con advertencia sobre impacto en la secuencia de numeración
+- Registro de auditoría en eliminación de remitos
+
 ## [1.2.0] - 2026-02-09
 
 ### Agregado

--- a/app/Http/Controllers/RtoController.php
+++ b/app/Http/Controllers/RtoController.php
@@ -1,6 +1,7 @@
 <?php
 namespace App\Http\Controllers;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use App\Models\Proveedor;
 use App\Models\rto;
 use App\Models\Camion;
@@ -210,6 +211,47 @@ class RtoController extends Controller
         ->get();
 
         return view('modules.rto.pendientes', compact('items', 'titulo', 'proveedores', 'anios', 'anioSeleccionado'));
+    }
+
+    public function destroy($id)
+    {
+        if (Gate::denies('acceso-remitos_eliminar')) {
+            return response()->json(['success' => false, 'message' => 'No tiene permiso para eliminar remitos.'], 403);
+        }
+
+        try {
+            $remito = rto::findOrFail($id);
+
+            if ($remito->estado !== 'Espera') {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Solo se pueden eliminar remitos en estado Espera.',
+                ], 422);
+            }
+
+            $datosAnteriores = $remito->toArray();
+
+            $camion = Camion::where('proveedores_id', $remito->proveedores_id)->first();
+            if ($camion && $camion->contador > 1) {
+                $camion->contador -= 1;
+                $camion->save();
+            }
+
+            $remito->delete();
+
+            AuditLog::registrar(
+                'remitos', 'eliminar',
+                "Elimino remito #{$remito->camion} del proveedor {$remito->proveedores_id}",
+                'Rto', (int) $id, $datosAnteriores
+            );
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Remito eliminado correctamente.',
+            ]);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
     }
 
     public function actualizarEstado(Request $request, $id)

--- a/app/Models/rto.php
+++ b/app/Models/rto.php
@@ -3,9 +3,11 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class rto extends Model
 {
+    use SoftDeletes;
     protected $table = 'rto';
     protected $primaryKey = 'id';
     protected $fillable = [

--- a/config/modulos.php
+++ b/config/modulos.php
@@ -11,6 +11,11 @@ return [
         'descripcion' => 'Gestion de remitos y documentacion',
         'icono' => 'fa-solid fa-file-signature',
     ],
+    'remitos_eliminar' => [
+        'nombre' => 'Remitos - Eliminar',
+        'descripcion' => 'Permite eliminar remitos en estado Espera',
+        'icono' => 'fa-solid fa-trash',
+    ],
     'reclamos' => [
         'nombre' => 'Reclamos',
         'descripcion' => 'Gestion de reclamos de remitos',

--- a/config/version.php
+++ b/config/version.php
@@ -1,5 +1,5 @@
 <?php
 
 return [
-    'number' => '1.2.2',
+    'number' => '1.2.3',
 ];

--- a/resources/views/modules/rto/index.blade.php
+++ b/resources/views/modules/rto/index.blade.php
@@ -87,6 +87,13 @@
         <a href="{{ route('reclamos.show', $item->id) }}" class="badge bg-danger" title="Ver Reclamos">
           <i class="fa-solid fa-triangle-exclamation"></i>
         </a>
+        @can('acceso-remitos_eliminar')
+        @if ($item->estado === 'Espera')
+        <a href="#" class="badge bg-danger eliminar-registro" data-id="{{ $item->id }}" title="Eliminar remito">
+          <i class="fa-solid fa-trash"></i>
+        </a>
+        @endif
+        @endcan
         </td>
 
         </tr>
@@ -190,6 +197,47 @@
         });
       });
     });
+    });
+
+    // Eliminar remito
+    document.querySelectorAll('.eliminar-registro').forEach(btn => {
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        const id = this.dataset.id;
+        Swal.fire({
+          title: '¿Eliminar remito?',
+          html: '<p>Esta acción <strong>no se puede deshacer</strong>.</p>' +
+                '<p class="mt-2 text-danger"><i class="fa-solid fa-triangle-exclamation"></i> <strong>Atención:</strong> Al eliminar este remito el contador del proveedor se decrementará, lo que puede generar <strong>huecos en la numeración</strong> de los camiones en tránsito.</p>' +
+                '<p class="mt-2">Proceda solo si está seguro de que este remito no afecta la secuencia activa de envíos.</p>',
+          icon: 'warning',
+          showCancelButton: true,
+          confirmButtonColor: '#d33',
+          cancelButtonColor: '#6c757d',
+          confirmButtonText: 'Entiendo, eliminar',
+          cancelButtonText: 'Cancelar'
+        }).then(result => {
+          if (!result.isConfirmed) return;
+          fetch(`/remitos/delete/${id}`, {
+            method: 'DELETE',
+            headers: {
+              'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+              'X-Requested-With': 'XMLHttpRequest'
+            }
+          })
+          .then(r => r.json())
+          .then(data => {
+            if (data.success) {
+              Swal.fire({ icon: 'success', title: 'Eliminado', text: data.message, timer: 1500, showConfirmButton: false });
+              const table = $('table.datatable').DataTable();
+              const row = btn.closest('tr');
+              table.row(row).remove().draw();
+            } else {
+              Swal.fire({ icon: 'error', title: 'Error', text: data.message });
+            }
+          })
+          .catch(() => Swal.fire({ icon: 'error', title: 'Error', text: 'No se pudo eliminar el remito.' }));
+        });
+      });
     });
   </script>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ Route::prefix('remitos')->middleware(['auth', 'Checkrol:remitos'])->group(functi
     Route::get('obtenerValor/{id}/{field}', [RtoDetalleController::class, 'obtenerValor'])->name('obtenerValor');
     Route::post('/deleteRtoDetalle/{id}', [RtoDetalleController::class, 'delete'])->name('deleteRtoDetalle');
     Route::get('pendientes', [RtoController::class, 'pendientes'])->name('remitos.pendientes');
+    Route::delete('/delete/{id}', [RtoController::class, 'destroy'])->name('remitos.destroy');
     Route::post('/actualizarEstado/{id}', [RtoController::class, 'actualizarEstado'])->name('actualizarEstado');
     Route::post('/remitos/actualizar/{id}', [RtoController::class, 'actualizar'])->name('actualizarRemito');
 });


### PR DESCRIPTION
- SoftDeletes en modelo rto (columna deleted_at ya existía en migración)
- RtoController::destroy(): valida estado Espera, decrementa contador camión, soft delete, auditoría
- Nuevo módulo 'remitos_eliminar' en config/modulos.php (gate acceso-remitos_eliminar)
- Ruta DELETE /remitos/delete/{id} dentro del grupo middleware remitos
- Vista: botón papelera visible solo con @can + @if estado Espera
- SweetAlert2 con advertencia sobre impacto en numeración de camiones en tránsito